### PR TITLE
Improve connection performance on expense creation

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,7 +80,7 @@ android {
         applicationId "com.kchen.Splitsies"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 24
+        versionCode 25
         versionName "1.4.2"
         resValue "string", "build_config_package", "com.kchen.Splitsies"
     }

--- a/ios/Splitsies.xcodeproj/project.pbxproj
+++ b/ios/Splitsies.xcodeproj/project.pbxproj
@@ -756,7 +756,7 @@
 				CODE_SIGN_ENTITLEMENTS = Splitsies/Splitsies.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6KH87N33A6;
 				ENABLE_BITCODE = NO;
@@ -796,7 +796,7 @@
 				CODE_SIGN_ENTITLEMENTS = Splitsies/Splitsies.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = "";
 				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 6KH87N33A6;
 				INFOPLIST_FILE = Splitsies/Info.plist;

--- a/src/api/expense-api-client/expense-api-client.i.ts
+++ b/src/api/expense-api-client/expense-api-client.i.ts
@@ -8,8 +8,8 @@ export interface IExpenseApiClient extends IBaseManager {
     getUserIdsForExpense(expenseId: string): Promise<string[]>;
     addUserToExpense(userId: string, expenseId: string, requestingUserId?: string): Promise<void>;
     removeUserFromExpense(userId: string, expenseId: string): Promise<void>;
-    createFromExpense(expense: IExpenseDto): Promise<string>;
-    createExpense(base64Image?: string): Promise<string>;
+    createFromExpense(expense: IExpenseDto): Promise<IExpenseDto | null>;
+    createExpense(base64Image?: string): Promise<IExpenseDto | null>;
     getExpenseJoinRequests(reset?: boolean): Promise<IUserExpenseDto[]>;
     getExpenseJoinRequestCount(): Promise<number>;
     removeExpenseJoinRequest(expenseId: string, userId?: string): Promise<void>;

--- a/src/api/expense-api-client/expense-api-client.ts
+++ b/src/api/expense-api-client/expense-api-client.ts
@@ -87,7 +87,7 @@ export class ExpenseApiClient extends ClientBase implements IExpenseApiClient {
         }
     }
 
-    async createFromExpense(expenseDto: IExpenseDto): Promise<string> {
+    async createFromExpense(expenseDto: IExpenseDto): Promise<IExpenseDto | null> {
         try {
             const body = { userId: this._authProvider.provideIdentity(), expense: expenseDto };
 
@@ -97,14 +97,14 @@ export class ExpenseApiClient extends ClientBase implements IExpenseApiClient {
                 this._authProvider.provideAuthHeader(),
             );
 
-            return response.success ? response.data.id : "";
+            return response.success ? response.data : null;
         } catch (e) {
             console.error(e);
-            return "";
+            return null;
         }
     }
 
-    async createExpense(base64Image: string | undefined = undefined): Promise<string> {
+    async createExpense(base64Image: string | undefined = undefined): Promise<IExpenseDto | null> {
         try {
             const body = { userId: this._authProvider.provideIdentity() };
             const response = await this.postJson<IExpenseDto>(
@@ -113,10 +113,10 @@ export class ExpenseApiClient extends ClientBase implements IExpenseApiClient {
                 this._authProvider.provideAuthHeader(),
             );
 
-            return response.success ? response.data.id : "";
+            return response.success ? response.data : null;
         } catch (e) {
             console.error(e);
-            return "";
+            return null;
         }
     }
 

--- a/src/components/ExpenseHeaderActionButton.tsx
+++ b/src/components/ExpenseHeaderActionButton.tsx
@@ -31,9 +31,9 @@ export const ExpenseHeaderActionButton = ({ currentExpense }: Props) => {
     const [awaitingResponse, setAwaitingResponse] = useState<boolean>(false);
 
     useInitialize(() => {
-        const sub = zip([_expenseViewModel.awaitingResponse$, _homeViewModel.pendingData$]).subscribe({
-            next: ([expensePendingData, homePendingData]) => {
-                setAwaitingResponse(expensePendingData || homePendingData);
+        const sub = zip([_expenseViewModel.awaitingResponse$, _expenseManager.connectionPending$]).subscribe({
+            next: ([expensePendingData, connectionPending]) => {
+                setAwaitingResponse(expensePendingData || connectionPending);
             },
         });
 

--- a/src/config/api-dev-pr.config.json
+++ b/src/config/api-dev-pr.config.json
@@ -2,6 +2,6 @@
     "expense": "https://c7g3im3s8c.execute-api.us-east-1.amazonaws.com/dev-pr/expenses",
     "expenseSocket": "wss://srzam2rrj5.execute-api.us-east-1.amazonaws.com/dev-pr",
     "users": "https://gzo0ijz6u0.execute-api.us-east-1.amazonaws.com/dev-pr/users",
-    "ocr": "https://2rr00kld14.execute-api.us-east-1.amazonaws.com/dev-pr/",
+    "ocr": "https://g8hji07hi3.execute-api.us-west-1.amazonaws.com/devpr/",
     "notification": "https://0whn6r18ud.execute-api.us-east-1.amazonaws.com/devpr/"
 }

--- a/src/managers/expense-manager/expense-manager-interface.ts
+++ b/src/managers/expense-manager/expense-manager-interface.ts
@@ -16,6 +16,8 @@ export interface IExpenseManager {
     readonly expenseJoinRequests$: Observable<IExpenseJoinRequest[]>;
     readonly expenseJoinRequestCount$: Observable<number>;
 
+    readonly connectionPending$: Observable<boolean>;
+
     requestForUser(reset?: boolean): Promise<void>;
     refreshCurrentExpense(): Promise<void>;
     connectToExpense(expenseId: string): Promise<boolean>;


### PR DESCRIPTION
avoids waiting for connection to complete in favor of navigating to the expense first, then queueing operations for post-connection